### PR TITLE
Cast dict key to int32, addresses #1

### DIFF
--- a/fast_hdbscan/boruvka.py
+++ b/fast_hdbscan/boruvka.py
@@ -6,7 +6,7 @@ from .numba_kdtree import parallel_tree_query, rdist, point_to_node_lower_bound_
 
 @numba.njit()
 def merge_components(disjoint_set, candidate_neighbors, candidate_neighbor_distances, point_components):
-    component_edges = {0: (0, np.int32(1), np.float32(0.0)) for i in range(0)}
+    component_edges = {np.int32(0): (0, np.int32(1), np.float32(0.0)) for i in range(0)}
 
     # Find the best edges from each component
     for i in range(candidate_neighbors.shape[0]):


### PR DESCRIPTION
This addresses #1.
I encountered the same problem as reported in #1. This PR fixes the issue on my Windows machine with Python 3.9.0 and numba version `0.56.4`.
 