### PR TITLE
Add extra conditions to azure devops pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,9 @@ pr:
     - doc/*
     - README.rst
 
+variables:
+  triggeredByPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
+
 stages:
   - stage: RunAllTests
     displayName: Run test suite
@@ -73,6 +76,7 @@ stages:
         - bash: |
             coveralls
           displayName: 'Publish to coveralls'
+          condition: and(succeeded(), eq(variables.triggeredByPullRequest, false)) # Don't run this for PRs because they can't access pipeline secrets
           env:
             COVERALLS_REPO_TOKEN: $(COVERALLS_TOKEN)
 
@@ -84,7 +88,7 @@ stages:
 
   - stage: BuildPublishArtifact
     dependsOn: RunAllTests
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/release-')
+    condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/release-'), eq(variables.triggeredByPullRequest, false))
     jobs:
       - job: BuildArtifacts
         displayName: Build source dists and wheels    
@@ -110,6 +114,18 @@ stages:
             python setup.py sdist bdist_wheel
           displayName: 'Build package'
 
+        - bash: |
+            export PACKAGE_VERSION="$(python setup.py --version)"
+            echo "Package Version: ${PACKAGE_VERSION}"
+            echo "##vso[task.setvariable variable=packageVersionFormatted;]release-${PACKAGE_VERSION}"
+          displayName: 'Get package version'
+
+        - script: |
+            echo "Version in git tag $(Build.SourceBranchName) does not match version derived from setup.py $(packageVersionFormatted)"
+            exit 1
+          displayName: Raise error if version doesnt match tag
+          condition: and(succeeded(), ne(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))
+
         - task: DownloadSecureFile@1
           name: PYPIRC_CONFIG
           displayName: 'Download pypirc'
@@ -120,4 +136,5 @@ stages:
             pip install twine
             twine upload --repository testpypi --config-file $(PYPIRC_CONFIG.secureFilePath) dist/* 
           displayName: 'Upload to PyPI'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))
 


### PR DESCRIPTION
Two main changes:

1. Test results will not be pushed to coveralls on pull requests. This is because we have disabled access to secrets on PRs from forks for security reasons. It will still work when the PR is merged or if the pipeline is run manually.
2. There is an additional check that tag specified in a release matches the package version from setup.py. If it doesn't it will fail the build and not push the package.