### PR TITLE
Add cluster_selection_epsilon parameter

### DIFF
--- a/fast_hdbscan/cluster_trees.py
+++ b/fast_hdbscan/cluster_trees.py
@@ -266,9 +266,8 @@ def eom_recursion(node, cluster_tree, node_scores, selected_clusters):
 
 
 @numba.njit()
-def extract_eom_clusters(condensed_tree, allow_single_cluster=False):
+def extract_eom_clusters(condensed_tree, cluster_tree, allow_single_cluster=False):
     node_scores = score_condensed_tree_nodes(condensed_tree)
-    cluster_tree = cluster_tree_from_condensed_tree(condensed_tree)
     selected_clusters = {node: False for node in node_scores}
 
     if len(cluster_tree.parent) == 0:
@@ -284,6 +283,62 @@ def extract_eom_clusters(condensed_tree, allow_single_cluster=False):
             eom_recursion(child_node, cluster_tree, node_scores, selected_clusters)
 
     return np.asarray([node for node, selected in selected_clusters.items() if selected])
+
+
+@numba.njit()
+def cluster_epsilon_search(clusters, cluster_tree, min_persistence=0.0):
+    selected = list()
+    # only way to create a typed empty set
+    processed = {np.int64(0)}
+    processed.clear()
+
+    root = cluster_tree.parent.min()
+    for cluster in clusters:
+        eps = 1 / cluster_tree.lambda_val[cluster_tree.child == cluster][0]
+        if eps < min_persistence:
+            if cluster not in processed:
+                parent = traverse_upwards(cluster_tree, min_persistence, root, cluster)
+                selected.append(parent)
+                processed |= segments_in_branch(cluster_tree, parent)
+        else:
+            selected.append(cluster)
+    return np.asarray(selected)
+
+
+@numba.njit()
+def traverse_upwards(cluster_tree, min_persistence, root, segment):
+    parent = cluster_tree.parent[cluster_tree.child == segment][0]
+    if parent == root:
+        return root
+    parent_eps = 1 / cluster_tree.lambda_val[cluster_tree.child == parent][0]
+    if parent_eps >= min_persistence:
+        return parent
+    else:
+        return traverse_upwards(cluster_tree, min_persistence, root, parent)
+
+
+@numba.njit()
+def segments_in_branch(cluster_tree, segment):
+    # only way to create a typed empty set
+    result = {np.intp(0)}
+    result.clear()
+    to_process = {segment}
+
+    while len(to_process) > 0:
+        result |= to_process
+        to_process = set(cluster_tree.child[
+            in_set_parallel(cluster_tree.parent, to_process)
+        ])
+
+    return result
+
+
+@numba.njit(parallel=True)
+def in_set_parallel(values, targets):
+  mask = np.empty(values.shape[0], dtype=numba.boolean)
+  for i in numba.prange(values.shape[0]):
+    mask[i] = values[i] in targets
+  return mask
 
 
 @numba.njit(parallel=True)
@@ -327,6 +382,7 @@ def get_cluster_labelling_at_cut(linkage_tree, cut, min_cluster_size):
 def get_cluster_label_vector(
         tree,
         clusters,
+        cluster_selection_epsilon
 ):
     root_cluster = tree.parent.min()
     result = np.empty(root_cluster, dtype=np.intp)
@@ -348,7 +404,13 @@ def get_cluster_label_vector(
         elif cluster == root_cluster:
             if len(clusters) == 1:
                 max_lambda = tree.lambda_val[tree.parent == cluster].max()
-                if tree.lambda_val[tree.child == n] >= max_lambda:
+                cur_lambda = tree.lambda_val[tree.child == n]
+                if cluster_selection_epsilon > 0.0:
+                    if cur_lambda >= 1 / cluster_selection_epsilon:
+                        result[n] = cluster_label_map[cluster]
+                    else:
+                        result[n] = -1
+                elif cur_lambda >= max_lambda:
                     result[n] = cluster_label_map[cluster]
                 else:
                     result[n] = -1

--- a/fast_hdbscan/tests/test_hdbscan.py
+++ b/fast_hdbscan/tests/test_hdbscan.py
@@ -131,6 +131,35 @@ def test_hdbscan_badargs():
     assert_raises(ValueError, fast_hdbscan, X, min_cluster_size="fail")
     assert_raises(ValueError, fast_hdbscan, X, min_samples="fail")
     assert_raises(ValueError, fast_hdbscan, X, min_samples=-1)
+    assert_raises(ValueError, fast_hdbscan, X, cluster_selection_epsilon="fail")
+    assert_raises(ValueError, fast_hdbscan, X, cluster_selection_epsilon=-1)
+    assert_raises(ValueError, fast_hdbscan, X, cluster_selection_epsilon=-0.1)
+    assert_raises(
+        ValueError, fast_hdbscan, X, cluster_selection_method="fail"
+    )
+
+
+def test_fhdbscan_allow_single_cluster_with_epsilon():
+    np.random.seed(0)
+    no_structure = np.random.rand(150, 2)
+    # without epsilon we should see 65 noise points and 9 labels
+    c = HDBSCAN(
+        min_cluster_size=5,
+        cluster_selection_epsilon=0.0,
+    ).fit(no_structure)
+    unique_labels, counts = np.unique(c.labels_, return_counts=True)
+    assert len(unique_labels) == 9
+    assert counts[unique_labels == -1] == 65
+
+    # An epsilon of 0.2 will produce 2 noise points and 2 labels
+    # Allow single cluster does not prevent applying the epsilon threshold.
+    c = HDBSCAN(
+        min_cluster_size=5,
+        cluster_selection_epsilon=0.2
+    ).fit(no_structure)
+    unique_labels, counts = np.unique(c.labels_, return_counts=True)
+    assert len(unique_labels) == 2
+    assert counts[unique_labels == -1] == 2
 
 
 # Disable for now -- need to refactor to meet newer standards


### PR DESCRIPTION
Thanks for this repository! This pull request implements the _cluster_selection_epsilon_ feature, which I have found useful in the past. I tried to port the previous implementation's relevant parts to numba without changing its structure too much. However, there is one notable difference: I stopped the _allow_single_cluster_ flag from affecting the epsilon threshold.

Let me know if things need to change for this pull request to be accpeted. I'll try to follow up on your comments!

