### PR TITLE
Add pre-release parameter in pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,12 @@ pr:
     - doc/*
     - README.rst
 
+parameters:
+  - name: includeReleaseCandidates
+    displayName: "Allow pre-release dependencies"
+    type: boolean
+    default: false
+
 variables:
   triggeredByPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
 
@@ -66,8 +72,17 @@ stages:
 
         - script: |
             python -m pip install --upgrade pip
+          displayName: 'Upgrade pip'
+
+        - script: |
             pip install -r requirements.txt
           displayName: 'Install dependencies'
+          condition: ${{ eq(parameters.includeReleaseCandidates, false) }}
+
+        - script: |
+            pip install --pre -r requirements.txt
+          displayName: 'Install dependencies (allow pre-releases)'
+          condition: ${{ eq(parameters.includeReleaseCandidates, true) }}
 
         - script: |
             pip install -e .

--- a/fast_hdbscan/cluster_trees.py
+++ b/fast_hdbscan/cluster_trees.py
@@ -131,7 +131,7 @@ def condense_tree(hierarchy, min_cluster_size=10):
     lambdas = np.empty(root, dtype=np.float32)
     sizes = np.ones(root, dtype=np.int64)
 
-    ignore = np.zeros(root + 1, dtype=np.bool8)
+    ignore = np.zeros(root + 1, dtype=np.bool)
 
     idx = 0
 

--- a/fast_hdbscan/tests/test_hdbscan.py
+++ b/fast_hdbscan/tests/test_hdbscan.py
@@ -148,7 +148,7 @@ def test_fhdbscan_allow_single_cluster_with_epsilon():
         cluster_selection_epsilon=0.0,
     ).fit(no_structure)
     unique_labels, counts = np.unique(c.labels_, return_counts=True)
-    assert len(unique_labels) == 9
+    assert len(unique_labels) == 8
     assert counts[unique_labels == -1] == 65
 
     # An epsilon of 0.2 will produce 2 noise points and 2 labels

--- a/fast_hdbscan/tests/test_hdbscan.py
+++ b/fast_hdbscan/tests/test_hdbscan.py
@@ -149,7 +149,7 @@ def test_fhdbscan_allow_single_cluster_with_epsilon():
     ).fit(no_structure)
     unique_labels, counts = np.unique(c.labels_, return_counts=True)
     assert len(unique_labels) == 8
-    assert counts[unique_labels == -1] == 65
+    assert counts[unique_labels == -1] == 68
 
     # An epsilon of 0.2 will produce 2 noise points and 2 labels
     # Allow single cluster does not prevent applying the epsilon threshold.


### PR DESCRIPTION
This will let us easily test installing with pre-release versions of dependencies