### PR TITLE
Modification to make semi-supervised part more efficient.

### DIFF
--- a/fast_hdbscan/hdbscan.py
+++ b/fast_hdbscan/hdbscan.py
@@ -202,7 +202,7 @@ def fast_hdbscan(
                     allow_virtual_nodes=True,
                     allow_single_cluster=allow_single_cluster,
                 )
-            elif ss_algorithm == "bc_without_vn":
+            elif ss_algorithm == "bc_simple":
                 selected_clusters = extract_clusters_bcubed(
                     condensed_tree,
                     cluster_tree,


### PR DESCRIPTION
I've made some changes to make the semi-supervised code scale better to very large datasets.

It can be tested as such:

`sshdbscan_clusterer = HDBSCAN(semi_supervised=True, ss_algorithm="bc").fit(X, y)`
or 
`sshdbscan_simple_clusterer = HDBSCAN(semi_supervised=True, ss_algorithm="bc_simple").fit(X, y)`

`bc_simple` simplifies the approach a bit by not considering singleton noisy labels (labelled examples that do not end up in a cluster when going from the hierarchical tree to the condensed tree). It can be more efficient when dealing with very large datasets without a significant loss in accuracy.

Thank you!