### PR TITLE
Precomputed MSTs

### DIFF
--- a/fast_hdbscan/cluster_trees.py
+++ b/fast_hdbscan/cluster_trees.py
@@ -409,7 +409,10 @@ def unselect_below_node_bcubed(node, cluster_tree, selected_clusters, unselected
             unselected_nodes[child] = True
 
 @numba.njit()
-def extract_clusters_bcubed(condensed_tree, cluster_tree, label_indices, allow_virtual_nodes=False, allow_single_cluster=False):
+def extract_clusters_bcubed(condensed_tree, cluster_tree, data_labels, allow_virtual_nodes=False, allow_single_cluster=False):
+    label_indices = Dict()
+    for index in np.flatnonzero(data_labels > -1):
+        label_indices[index] = data_labels[index]
 
     if allow_virtual_nodes:
 


### PR DESCRIPTION
It would be very nice if `fast_hdbscan` had an entry point that takes a minimum spanning tree and gives the cluster hierarchy and labelling. That would enable re-use of this project's code when experimenting with different kind of edge weights. 

This PR creates such a function without changing the existing API. I have moved the relevant functionality from `fast_hdbscan` into a new function called `fast_hdbscan_mst_edges`, which is then called by the original `fast_hdbscan`. A test is added to make sure future re-factoring does not break `fast_hdbscan_mst_edges`.

Please let me know if things need to change to be ready for merging.