### PR TITLE
Silence divide by zero warnings in branch detection code

### DIFF
--- a/fast_hdbscan/branches.py
+++ b/fast_hdbscan/branches.py
@@ -6,7 +6,8 @@ def compute_centrality(data, probabilities, *args):
     points = args[-1]
     cluster_data = data[points, :]
     centroid = np.average(cluster_data, weights=probabilities[points], axis=0)
-    return 1 / np.linalg.norm(cluster_data - centroid[None, :], axis=1)
+    with np.errstate(divide="ignore"):
+        return 1 / np.linalg.norm(cluster_data - centroid[None, :], axis=1)
 
 
 def apply_branch_threshold(


### PR DESCRIPTION
Mimics [#669](https://github.com/scikit-learn-contrib/hdbscan/pull/669) to resolve [#668](https://github.com/scikit-learn-contrib/hdbscan/issues/668) on the other repository to repository. Effectively silences numpy's divide by zero warnings that can occur in the branch detection code.