### PR TITLE
Subcluster fixes

### DIFF
--- a/fast_hdbscan/core_graph.py
+++ b/fast_hdbscan/core_graph.py
@@ -109,7 +109,7 @@ def select_components(distances, indices, indptr, point_components):
     # Find the best edges from each component
     for parent, from_component in enumerate(point_components):
         start = indptr[parent]
-        if indices[start] == -1:
+        if start == len(indices) or indices[start] == -1:
             continue
 
         neighbor = indices[start]

--- a/fast_hdbscan/sub_clusters.py
+++ b/fast_hdbscan/sub_clusters.py
@@ -314,6 +314,8 @@ def find_sub_clusters(
             f"Invalid cluster_selection_method: {cluster_selection_method}\n"
             f'Should be one of: "eom", "leaf"\n'
         )
+    if np.all(cluster_labels == -1):
+        raise ValueError("Input contains only noise points.")
 
     # Recover finite data points
     data = clusterer._raw_data
@@ -449,7 +451,7 @@ class SubClusterDetector(ClusterMixin, BaseEstimator):
         *,
         lens_values=None,
         min_cluster_size=None,
-        max_cluster_size=np.inf,
+        max_cluster_size=None,
         allow_single_cluster=False,
         cluster_selection_method="eom",
         cluster_selection_epsilon=0.0,

--- a/fast_hdbscan/tests/test_sub_clusters.py
+++ b/fast_hdbscan/tests/test_sub_clusters.py
@@ -192,3 +192,5 @@ def test_badargs():
             c,
             cluster_selection_method="something_else",
         )
+    with pytest.raises(ValueError):
+        find_sub_clusters(c, cluster_labels=np.full_like(c.labels_, -1))


### PR DESCRIPTION
A couple of small fixes for the sub-cluster code: 

- use correct default `max_cluster_size` in `SubClusterDetector`
- check `indptr` value before accesses to avoid potential segfaults.
- error early when all input points are noise