### PR TITLE
simplify and optimise applying persistence thresholds

### DIFF
--- a/fast_hdbscan/cluster_trees.py
+++ b/fast_hdbscan/cluster_trees.py
@@ -545,70 +545,63 @@ def extract_eom_clusters(condensed_tree, cluster_tree, max_cluster_size=np.inf, 
 
 
 @numba.njit()
-def simplify_hierarchy(condensed_tree, n_points, persistence_threshold):
-    keep_mask = np.ones(condensed_tree.parent.shape[0], dtype=np.bool_)
+def simplify_hierarchy(condensed_tree, persistence_threshold):
     cluster_tree = cluster_tree_from_condensed_tree(condensed_tree)
+    n_points = condensed_tree.parent[0]
+    n_nodes = cluster_tree.child[-1] + 1
 
-    processed = {np.int64(0)}
-    processed.clear()
-    while cluster_tree.parent.shape[0] > 0:
-        leaves = set(cluster_tree_leaves(cluster_tree, n_points))
-        births = max_lambdas(condensed_tree, leaves)
-        deaths = min_lambdas(cluster_tree, leaves)
+    # track state and changes
+    leaf_indicator = np.ones(n_nodes - n_points, dtype=np.bool_)
+    leaf_indicator[cluster_tree.parent - n_points] = False
+    max_births = np.empty(n_nodes - n_points, dtype=np.float32)
+    max_births[condensed_tree.parent - n_points] = condensed_tree.lambda_val
+    parent_map = np.arange(n_points, n_nodes, dtype=np.int64)
+    lambda_map = {np.int64(0): np.float32(0) for _ in range(0)}
 
-        cluster_mask = np.ones(cluster_tree.parent.shape[0], dtype=np.bool_)
-        for leaf in sorted(leaves, reverse=True):
-            if leaf in processed or (births[leaf] - deaths[leaf]) >= persistence_threshold:
-                continue
-            
-            # Find rows for leaf and sibling
-            leaf_idx = np.searchsorted(cluster_tree.child, leaf)
-            parent = cluster_tree.parent[leaf_idx]
-            if leaf_idx > 0 and cluster_tree.parent[leaf_idx - 1] == parent:
-                sibling_idx = leaf_idx - 1 
-            else:
-                sibling_idx = leaf_idx + 1
-            sibling = cluster_tree.child[sibling_idx]
-                        
-            # Update parent values to the new parent
-            for idx, row in enumerate(cluster_tree.parent):
-                if row in [leaf, sibling]:
-                    cluster_tree.parent[idx] = parent
-            for idx, row in enumerate(condensed_tree.parent):
-                if row in [leaf, sibling]:
-                    condensed_tree.parent[idx] = parent
-                    condensed_tree.lambda_val[idx] = deaths[leaf]
-            
-            # Mark visited rows
-            processed.add(leaf)
-            processed.add(sibling)
-            cluster_mask[leaf_idx] = False
-            cluster_mask[sibling_idx] = False
-            for idx, child in enumerate(condensed_tree.child):
-                if child in [leaf, sibling]:
-                    keep_mask[idx] = False
+    # reverse order guarantees children are processed before parents
+    for idx in range(cluster_tree.parent.shape[0] - 1, 0, -2):
+        parent = cluster_tree.parent[idx]
+        children = cluster_tree.child[idx - 1 : idx + 1]
+        death = cluster_tree.lambda_val[idx]
+        node_indices = children - n_points
+        births = max_births[node_indices]
 
-        if np.all(cluster_mask):
-            break
-        cluster_tree = mask_condensed_tree(cluster_tree, cluster_mask)
+        # propagate max density so only leaves can fail the persistence threshold
+        max_births[parent - n_points] = max(max_births[parent - n_points], births.max())
+        if (births.min() - death) >= persistence_threshold:
+            continue
 
-    condensed_tree = mask_condensed_tree(condensed_tree, keep_mask)
-    return remap_cluster_ids(condensed_tree, n_points)
+        # sibling is the most persistent child
+        sibling_idx = np.int64(births[0] <= births[1])
+        if leaf_indicator[node_indices[sibling_idx]]:
+            leaf_indicator[parent - n_points] = True
+        else:
+            lambda_map[children[1 - sibling_idx]] = death
+        parent_map[node_indices] = parent
 
+    # propagate and relabel for consecutive numbering
+    n_skipped = np.zeros(parent_map.shape[0], dtype=np.bool_)
+    for i, parent in enumerate(parent_map):
+        parent_map[i] = parent_map[parent - n_points]
+    for i, parent in enumerate(parent_map):
+        n_skipped[i] = parent != (i + n_points)
+        parent_map[i] = parent - n_skipped[: parent - n_points].sum()
 
-@numba.njit()
-def remap_cluster_ids(condensed_tree, n_points):
-    n_nodes = condensed_tree.parent.max() + 1
-    remaining_parents = np.unique(condensed_tree.parent)
-    id_map = np.empty(n_nodes - n_points, dtype=np.int64)
-    id_map[remaining_parents - n_points] = np.arange(
-        n_points, n_points + remaining_parents.shape[0]
-    )
-    for column in [condensed_tree.parent, condensed_tree.child]:
-        for idx, node in enumerate(column):
-            if node >= n_points:
-                column[idx] = id_map[node - n_points]
-    return condensed_tree
+    # apply changes
+    keep_mask = np.ones(condensed_tree.parent.shape[0], dtype=np.bool_)
+    for idx, (parent, child, lambda_val) in enumerate(
+        zip(condensed_tree.parent, condensed_tree.child, condensed_tree.lambda_val)
+    ):
+        keep_mask[idx] = not n_skipped[max(child - n_points, 0)]
+        if not keep_mask[idx]:
+            continue
+
+        condensed_tree.lambda_val[idx] = lambda_map.get(parent, lambda_val)
+        condensed_tree.parent[idx] = parent_map[parent - n_points]
+        if child >= n_points:
+            condensed_tree.child[idx] = parent_map[child - n_points]
+
+    return mask_condensed_tree(condensed_tree, keep_mask)
 
 
 @numba.njit()
@@ -769,14 +762,6 @@ def max_lambdas(tree, clusters):
             result[cluster] = max(result[cluster], tree.lambda_val[n])
 
     return result
-
-
-@numba.njit()
-def min_lambdas(cluster_tree, clusters):
-    return {
-        c: cluster_tree.lambda_val[np.searchsorted(cluster_tree.child, c)] 
-        for c in clusters
-    }
 
 
 @numba.njit()

--- a/fast_hdbscan/hdbscan.py
+++ b/fast_hdbscan/hdbscan.py
@@ -240,9 +240,9 @@ def clusters_from_spanning_tree(
     condensed_tree = condense_tree(
         linkage_tree, min_cluster_size=min_cluster_size, sample_weights=sample_weights
     )
-    if cluster_selection_persistence > 0.0:
+    if cluster_selection_persistence > 0.0 and len(condensed_tree.parent) > 0:
         condensed_tree = simplify_hierarchy(
-            condensed_tree, n_points, cluster_selection_persistence
+            condensed_tree, cluster_selection_persistence
         )
     
     cluster_tree = cluster_tree_from_condensed_tree(condensed_tree)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.21
 numba>=0.56
-scikit-learn>=1.1
+scikit-learn>=1.6


### PR DESCRIPTION
This PR simplifies and optimises the `simplify_hierarchy` function. It turns out that `simplify_hierarchy` reduces to iterating over the cluster_tree in reverse order (so children are processed before their parents).

The PR introduces one behavioural change to simplify_hierarchy. Density values are no longer updated when two leaves combine into one. This change ensures that the resulting leaf-combination retains its full density range. Consequently, the resulting simplified tree more accurately reflects the persistence threshold. Only when a leaf merges into a non-leaf are the leaf's density values updated to avoid breaking the condensed tree plot. Those points can have densities higher than the non-leaf's birth density, resulting in child clusters breaking off from a parent cluster before its icicle ends.

I also bumped the minimum version for scikit-learn to 1.6 because the new parameter names are used:
https://github.com/TutteInstitute/fast_hdbscan/blob/2b70ffe69224d9d88ee42db748991a6db7a7320c/fast_hdbscan/hdbscan.py#L332 
https://github.com/TutteInstitute/fast_hdbscan/blob/2b70ffe69224d9d88ee42db748991a6db7a7320c/fast_hdbscan/hdbscan.py#L478