### PR TITLE
fix: handle all sklearn node_data formats in kdtree_to_numba

### DIFF
--- a/fast_hdbscan/numba_kdtree.py
+++ b/fast_hdbscan/numba_kdtree.py
@@ -35,27 +35,33 @@ NumbaKDTreeType = numba.types.NamedTuple(
 
 def kdtree_to_numba(sklearn_kdtree):
     data, idx_array, node_data, node_bounds = sklearn_kdtree.get_arrays()
-    try:
-        return NumbaKDTree(
-            data,
-            idx_array,
-            node_data.idx_start,
-            node_data.idx_end,
-            node_data.radius,
-            node_data.is_leaf,
-            node_bounds,
-        )
-    except AttributeError:
-        # For older versions of sklearn, node_data is a tuple of arrays rather than a named tuple
-        return NumbaKDTree(
-            data,
-            idx_array,
-            node_data["idx_start"],
-            node_data["idx_end"],
-            node_data["radius"],
-            node_data["is_leaf"],
-            node_bounds,
-        )
+
+    if (
+        hasattr(node_data, "dtype")
+        and hasattr(node_data.dtype, "names")
+        and node_data.dtype.names is not None
+    ):
+        # Structured array: access by field name (current sklearn versions)
+        idx_start = np.asarray(node_data["idx_start"], dtype=np.intp)
+        idx_end = np.asarray(node_data["idx_end"], dtype=np.intp)
+        radius = np.asarray(node_data["radius"], dtype=np.float32)
+        is_leaf = np.asarray(node_data["is_leaf"], dtype=np.bool_)
+    else:
+        # Named tuple or object with attributes (older sklearn versions)
+        idx_start = np.asarray(node_data.idx_start, dtype=np.intp)
+        idx_end = np.asarray(node_data.idx_end, dtype=np.intp)
+        radius = np.asarray(node_data.radius, dtype=np.float32)
+        is_leaf = np.asarray(node_data.is_leaf, dtype=np.bool_)
+
+    return NumbaKDTree(
+        data,
+        idx_array,
+        idx_start,
+        idx_end,
+        radius,
+        is_leaf,
+        node_bounds,
+    )
 
 
 @numba.njit(

--- a/fast_hdbscan/tests/test_kdtree.py
+++ b/fast_hdbscan/tests/test_kdtree.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+from sklearn.datasets import load_iris
+from sklearn.neighbors import KDTree
+
+from fast_hdbscan.numba_kdtree import NumbaKDTree, kdtree_to_numba
+
+
+def test_kdtree_to_numba_basic():
+    X, _ = load_iris(return_X_y=True)
+    sklearn_tree = KDTree(X)
+    numba_tree = kdtree_to_numba(sklearn_tree)
+    assert isinstance(numba_tree, NumbaKDTree)
+    assert numba_tree.data.shape == X.shape
+    assert len(numba_tree.idx_array) == X.shape[0]
+    assert numba_tree.idx_start.dtype == np.intp
+    assert numba_tree.idx_end.dtype == np.intp
+    assert numba_tree.radius.dtype == np.float32
+    assert numba_tree.is_leaf.dtype == np.bool_
+
+
+def test_kdtree_to_numba_small():
+    X = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    sklearn_tree = KDTree(X)
+    numba_tree = kdtree_to_numba(sklearn_tree)
+    assert numba_tree.data.shape == (4, 2)
+    assert np.all(numba_tree.idx_start >= 0)
+    assert np.all(numba_tree.idx_end >= numba_tree.idx_start)
+
+
+def test_kdtree_to_numba_attribute_style():
+    """Test fallback when node_data has attribute-style access (namedtuple-like)."""
+    X = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    sklearn_tree = KDTree(X)
+    data, idx_array, node_data, node_bounds = sklearn_tree.get_arrays()
+
+    class AttrNodeData:
+        def __init__(self, nd):
+            self.idx_start = nd["idx_start"]
+            self.idx_end = nd["idx_end"]
+            self.is_leaf = nd["is_leaf"]
+            self.radius = nd["radius"]
+            self.dtype = type("dtype", (), {"names": None})()
+
+    attr_node_data = AttrNodeData(node_data)
+
+    class FakeTree:
+        def get_arrays(self):
+            return data, idx_array, attr_node_data, node_bounds
+
+    numba_tree = kdtree_to_numba(FakeTree())
+    assert isinstance(numba_tree, NumbaKDTree)
+    assert numba_tree.data.shape == (4, 2)


### PR DESCRIPTION
## Summary

- Fixes #60 — `AttributeError` when using `kdtree_to_numba` with recent sklearn versions
- Detects `node_data` format at runtime (structured array with named fields vs object with attributes) and extracts fields accordingly
- Adds explicit dtype casting (`np.intp`, `np.float32`, `np.bool_`) for numba type safety
- Adds 3 tests for `kdtree_to_numba` covering both formats

## Test plan

- [x] `uv run pytest fast_hdbscan/tests/test_kdtree.py -v` — 3/3 passed
- [x] `uv run pytest fast_hdbscan/tests/ -v` — 231 passed, 7 skipped