### PR TITLE
fix: handle single-point input + add edge case tests

### DIFF
--- a/fast_hdbscan/hdbscan.py
+++ b/fast_hdbscan/hdbscan.py
@@ -91,6 +91,12 @@ def _check_sample_weight(
 
 
 def to_numpy_rec_array(named_tuple_tree):
+    # If already a structured numpy array (e.g. from degenerate input), return as-is
+    if (
+        isinstance(named_tuple_tree, np.ndarray)
+        and named_tuple_tree.dtype.names is not None
+    ):
+        return named_tuple_tree
     size = named_tuple_tree.parent.shape[0]
     result = np.empty(
         size,
@@ -267,6 +273,35 @@ def fast_hdbscan(
         raise ValueError(
             "Cluster selection persistence must be a positive floating point number!"
         )
+
+    # Handle degenerate case: single point cannot form any cluster
+    if data.shape[0] < 2:
+        n = data.shape[0]
+        labels = np.full(n, -1, dtype=np.intp)
+        probabilities = np.zeros(n, dtype=np.float64)
+        single_linkage_tree = np.zeros((0, 4), dtype=np.float64)
+        condensed_tree = np.zeros(
+            0,
+            dtype=[
+                ("parent", np.intp),
+                ("child", np.intp),
+                ("lambda_val", np.float64),
+                ("child_size", np.intp),
+            ],
+        )
+        mst = np.zeros((0, 3), dtype=np.float64)
+        neighbors = np.zeros((n, 0), dtype=np.intp)
+        core_distances = np.full(n, np.inf, dtype=np.float64)
+        result = (
+            labels,
+            probabilities,
+            single_linkage_tree,
+            condensed_tree,
+            mst,
+            neighbors,
+            core_distances,
+        )
+        return result[: (None if return_trees else 2)]
 
     minimum_spanning_tree, neighbors, core_distances = compute_minimum_spanning_tree(
         data,

--- a/fast_hdbscan/tests/test_edge_cases.py
+++ b/fast_hdbscan/tests/test_edge_cases.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pytest
+from sklearn.datasets import make_blobs
+from fast_hdbscan import HDBSCAN
+
+
+class TestEdgeCaseInputs:
+    def test_single_point(self):
+        """A single point should be labeled as noise."""
+        X = np.array([[1.0, 2.0]])
+        labels = HDBSCAN(min_cluster_size=2).fit_predict(X)
+        assert labels[0] == -1
+
+    def test_two_points(self):
+        """Two points with min_cluster_size=2 should form one cluster."""
+        X = np.array([[0.0, 0.0], [0.1, 0.0]])
+        labels = HDBSCAN(min_cluster_size=2).fit_predict(X)
+        assert len(set(labels) - {-1}) <= 1
+
+    def test_duplicate_points(self):
+        """All identical points should not crash."""
+        X = np.full((50, 3), 1.0)
+        labels = HDBSCAN(min_cluster_size=5).fit_predict(X)
+        assert len(labels) == 50
+
+    def test_min_cluster_size_larger_than_n_samples(self):
+        """When min_cluster_size > n_samples, all points should be noise."""
+        np.random.seed(42)
+        X = np.random.rand(10, 2)
+        labels = HDBSCAN(min_cluster_size=100).fit_predict(X)
+        assert np.all(labels == -1)
+
+    def test_one_dimensional_data(self):
+        """1D data should cluster without error."""
+        np.random.seed(42)
+        X = np.concatenate(
+            [
+                np.random.normal(0, 0.1, 50),
+                np.random.normal(5, 0.1, 50),
+            ]
+        ).reshape(-1, 1)
+        labels = HDBSCAN(min_cluster_size=10).fit_predict(X)
+        n_clusters = len(set(labels) - {-1})
+        assert n_clusters >= 1
+
+    def test_high_min_samples(self):
+        """min_samples close to n_samples should not crash."""
+        np.random.seed(42)
+        X = np.random.rand(20, 2)
+        labels = HDBSCAN(min_cluster_size=5, min_samples=18).fit_predict(X)
+        assert len(labels) == 20
+
+    def test_epsilon_zero(self):
+        """cluster_selection_epsilon=0 should behave normally."""
+        X, _ = make_blobs(n_samples=200, centers=3, random_state=42)
+        labels = HDBSCAN(
+            min_cluster_size=10, cluster_selection_epsilon=0.0
+        ).fit_predict(X)
+        assert len(set(labels) - {-1}) >= 1
+
+    def test_epsilon_very_large(self):
+        """Very large epsilon should merge everything into one cluster."""
+        X, _ = make_blobs(n_samples=200, centers=3, random_state=42)
+        labels = HDBSCAN(
+            min_cluster_size=10,
+            cluster_selection_epsilon=1000.0,
+            allow_single_cluster=True,
+        ).fit_predict(X)
+        n_clusters = len(set(labels) - {-1})
+        assert n_clusters <= 1


### PR DESCRIPTION
## Summary

- Fixes crash when fitting a single data point (early return guard in `fast_hdbscan()`)
- Adds 8 edge case tests covering degenerate inputs:
  - Single point, two points, all duplicate points
  - `min_cluster_size` > `n_samples`
  - 1D data, high `min_samples`
  - `cluster_selection_epsilon` at 0 and very large values

## Test plan

- [x] `uv run pytest fast_hdbscan/tests/test_edge_cases.py -v` — 8/8 passed
- [x] `uv run pytest fast_hdbscan/tests/ -v` — 236 passed, 7 skipped