### PR TITLE
ci: add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.12"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.13"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[nndescent]"
+          pip install pytest
+
+      - name: Run tests
+        run: pytest fast_hdbscan/tests/ -v --tb=short


### PR DESCRIPTION
## Summary

Adds a basic GitHub Actions workflow that runs the test suite on pushes to `main` and pull requests.

## What it does

- Runs `pytest fast_hdbscan/tests/` across:
  - **OS**: Ubuntu, macOS, Windows
  - **Python**: 3.10, 3.11, 3.12, 3.13 (matching `pyproject.toml` classifiers)
- Installs the package with the `nndescent` optional extra so all tests can run
- `fail-fast: false` so one platform failure doesn't hide issues on others

## Motivation

The repo has a solid test suite (~4.3k lines across 10 test files) but no automated CI. This means:
- Regressions can slip through unnoticed until a user reports them
- Contributors have no quick signal on whether their PR breaks something
- Multi-platform / multi-Python compatibility is only verified manually

This workflow is intentionally minimal — just pytest, no linters, no coverage gates — to keep the setup lightweight and match the project's current style.

## Test plan

- [ ] Workflow runs on this PR
- [ ] Tests pass on all matrix combinations (or surface real issues to triage)